### PR TITLE
fix: drop card move-up animation on mobile horizontal scroll

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,10 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+# Install dependencies when a workspace is created.
+setup = "pnpm install"
+# Start the Next.js dev server on this workspace's assigned port.
+run = "pnpm dev --port $CONDUCTOR_PORT"
+# Each workspace runs on its own port with no shared local resource,
+# so multiple workspaces can run at the same time.
+run_mode = "concurrent"

--- a/src/components/animation/FadeIn.tsx
+++ b/src/components/animation/FadeIn.tsx
@@ -23,6 +23,10 @@ const FadeIn = ({
 
   return (
     <motion.div
+      // Framer reads `initial` only at mount. `isMobile` resolves after mount
+      // (SSR-safe), so remount when it flips to pick up the corrected offset —
+      // otherwise the resting y stays at 32 and the move-up still plays.
+      key={staticOnMobile ? `fade-${isMobile ? "static" : "shift"}` : undefined}
       initial={{ opacity: 0, y: offsetY }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.3 }}

--- a/src/components/animation/FadeIn.tsx
+++ b/src/components/animation/FadeIn.tsx
@@ -1,16 +1,29 @@
 import { motion, type HTMLMotionProps } from "framer-motion";
 import type { ReactNode } from "react";
+import { useIsMobile } from "~/hooks/useIsMobile";
 
 type FadeInProps = {
   children: ReactNode;
   delay?: number;
   y?: number;
+  // When true, skip the vertical move-up on mobile so cards in a horizontal
+  // scroller just fade in (the upward shift feels jarring mid horizontal-scroll).
+  staticOnMobile?: boolean;
 } & HTMLMotionProps<"div">;
 
-const FadeIn = ({ children, delay = 0, y = 32, ...rest }: FadeInProps) => {
+const FadeIn = ({
+  children,
+  delay = 0,
+  y = 32,
+  staticOnMobile = false,
+  ...rest
+}: FadeInProps) => {
+  const isMobile = useIsMobile();
+  const offsetY = staticOnMobile && isMobile ? 0 : y;
+
   return (
     <motion.div
-      initial={{ opacity: 0, y }}
+      initial={{ opacity: 0, y: offsetY }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.3 }}
       transition={{ duration: 0.6, ease: "easeOut", delay }}

--- a/src/components/education/CompetitionCard.tsx
+++ b/src/components/education/CompetitionCard.tsx
@@ -11,6 +11,7 @@ const CompetitionCard: React.FC<Props> = ({ data, isInView }) => {
 
   return (
     <FadeIn
+      staticOnMobile
       className={`${cardStateClass} flex w-64 transform snap-x snap-center flex-col border border-white/20 bg-white/5 p-8 transition-all duration-300 ease-in-out xs:w-72 md:w-full md:snap-none`}
     >
       <h3 className="heading3">{data.title}</h3>

--- a/src/components/education/CourseAchievementCard.tsx
+++ b/src/components/education/CourseAchievementCard.tsx
@@ -22,6 +22,7 @@ const CourseAchievementCard: React.FC<Props> = ({ data, isInView }) => {
 
   return (
     <FadeIn
+      staticOnMobile
       className={`${cardStateClass} flex w-64 transform snap-x snap-center flex-col border border-white/20 bg-white/5 p-8 transition-all duration-300 ease-in-out xs:w-72 md:w-full md:snap-none`}
     >
       <h3 className="heading3">{data.course}</h3>

--- a/src/components/experience/ExperienceCard.tsx
+++ b/src/components/experience/ExperienceCard.tsx
@@ -50,6 +50,7 @@ const ExperienceCard = ({
 
   return (
     <FadeIn
+      staticOnMobile
       className={`${cardState} group flex w-64 transform snap-x snap-center flex-col border border-white/20 bg-white/5 p-8 transition-all duration-300 ease-in-out xs:w-72 md:w-full md:snap-none md:hover:grayscale-0 md:active:grayscale-0`}
     >
       <div className="flex items-center gap-4 pb-4">

--- a/src/components/projects/AllProjects.tsx
+++ b/src/components/projects/AllProjects.tsx
@@ -12,7 +12,7 @@ const AllProjects: React.FC = () => {
       onScroll={handleScroll}
     >
       {projectsData.map((p, i) => (
-        <FadeIn key={`${p.title}-${i}`}>
+        <FadeIn key={`${p.title}-${i}`} staticOnMobile>
           <ProjectCard {...p} isInView={snappedIndex === i} />
         </FadeIn>
       ))}

--- a/src/components/volunteering/VolunteerCard.tsx
+++ b/src/components/volunteering/VolunteerCard.tsx
@@ -17,6 +17,7 @@ const VolunteerCard: React.FC<Props> = ({
 
   return (
     <FadeIn
+      staticOnMobile
       className={`${cardStateClass} flex h-full w-64 min-w-[16rem] transform snap-x snap-center flex-col items-center justify-center border border-white/20 bg-white/5 p-8 transition-all duration-300 ease-in-out xs:w-72 md:h-fit md:w-full md:items-start md:justify-start md:hover:grayscale-0 md:active:grayscale-0`}
     >
       <div className="flex flex-col items-center md:flex-row md:space-x-8">

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+// Matches Tailwind's `md` breakpoint (768px). Below it, the card sections
+// switch from a static grid to a horizontal scroller.
+const MOBILE_QUERY = "(max-width: 767px)";
+
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const update = () => setIsMobile(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  return isMobile;
+};


### PR DESCRIPTION
On mobile the project/experience/education/volunteer sections are horizontal scrollers, but each card was animated in with `FadeIn`'s vertical move-up (`y: 32 → 0`), so scrolling sideways triggered a jarring upward shift on every card. This adds an opt-in `staticOnMobile` prop to `FadeIn` — backed by a new `useIsMobile` hook keyed to the `md`/768px breakpoint where the layout switches from horizontal scroll to a static grid — that keeps the fade-in but skips the vertical translate below that breakpoint. The prop is applied to the projects, experience, competitions, course-achievement, and volunteer card sections; the one-time vertical fade-ins on the hero and education-summary blocks, and all desktop behavior, are unchanged.