### PR TITLE
Update Lyra experience to Paraform Series B with apply CTA

### DIFF
--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -79,14 +79,13 @@ export const experienceData: ExperienceItem[] = [
     location: "Sydney, NSW, Australia",
     start: "June 2025",
     end: "Present",
-    highlights: [
-      "Deployed as a Forward Deployed Engineer through Lyra Technologies to Paraform, a US-based recruitment startup, shipping daily full-stack features into production.",
-      "Built end-to-end enterprise integrations across multiple platforms including SendGrid, Salesforce, Slack, and customer support tooling.",
-      "Designed and maintained 370+ analytics queries and dashboards covering product metrics, activation funnels, and performance insights.",
-      "Optimised critical API endpoints to significantly improve response times and reduce database load.",
-    ],
+    highlights: ["Working with Paraform – $65M Series B."],
     logo: "/images/lyra-logo.svg",
     logoAlt: "Lyra logo",
+    callToAction: {
+      label: "Join our team",
+      href: "https://bit.ly/applytolyra",
+    },
   },
   {
     company: "UNSW",


### PR DESCRIPTION
Updates the Lyra work-experience entry on the portfolio. The four previous highlight bullets are replaced with a single line — "Working with Paraform – $65M Series B." — and the entry now uses the card's built-in `callToAction` field to render a clickable "Join our team" button linking to https://bit.ly/applytolyra (opens in a new tab). No component or type changes were needed since `callToAction` already exists on `ExperienceItem`.