### PR TITLE
Update education course results

### DIFF
--- a/src/components/education/CourseAchievementCard.tsx
+++ b/src/components/education/CourseAchievementCard.tsx
@@ -1,21 +1,38 @@
 import FadeIn from "../animation/FadeIn";
-import { type CourseAchievementCardDataType } from "~/types/types";
+import {
+  type CompetencyGradeCode,
+  type CourseAchievementCardDataType,
+  type CourseResultType,
+} from "~/types/types";
 
 type Props = {
   data: CourseAchievementCardDataType;
 };
 
+const competencyGradeDescriptions = {
+  CM: "Received a Competent with Merit Grade",
+  CO: "Received a Competent Grade",
+  CN: "",
+} satisfies Record<CompetencyGradeCode, string>;
+
 const CourseAchievementCard: React.FC<Props> = ({ data }) => {
-  const getGradeDescription = (grade?: number) => {
-    if (!grade) return "";
-    if (grade >= 85) {
+  const getResultDescription = (result?: CourseResultType) => {
+    if (!result) return "";
+    if (result.type === "competency") {
+      return competencyGradeDescriptions[result.code];
+    }
+
+    if (result.mark >= 85) {
       return "Received a High Distinction Grade";
-    } else if (grade >= 75) {
+    } else if (result.mark >= 75) {
       return "Received a Distinction Grade";
     } else {
       return "";
     }
   };
+
+  const resultDescription = getResultDescription(data.result);
+  const yearLabel = data.term ? `${data.year} ${data.term}` : data.year;
 
   return (
     <FadeIn
@@ -24,12 +41,10 @@ const CourseAchievementCard: React.FC<Props> = ({ data }) => {
     >
       <h3 className="heading3">{data.course}</h3>
       <div className="py-4">
-        {getGradeDescription(data.grade) !== "" && (
-          <p className="subtitle font-light">
-            {getGradeDescription(data.grade)}
-          </p>
+        {resultDescription !== "" && (
+          <p className="subtitle font-light">{resultDescription}</p>
         )}
-        <p className="subtitle font-light opacity-60">{data.year}</p>
+        <p className="subtitle font-light opacity-60">{yearLabel}</p>
       </div>
       <p className="subtitle font-light">{data.description}</p>
     </FadeIn>

--- a/src/sections/EducationSection.tsx
+++ b/src/sections/EducationSection.tsx
@@ -27,7 +27,7 @@ const EducationSection = () => {
                 Bachelor of Engineering (Honours) (Software)
               </h3>
               <p className="para1 opacity-60">University of New South Wales</p>
-              <p className="subtitle opacity-60">2022 - 2025</p>
+              <p className="subtitle opacity-60">2022 - 2026</p>
             </div>
           </div>
         </FadeIn>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -17,11 +17,26 @@ export type VolunteeringDataType = {
   description?: string;
 };
 
+export type CompetencyGradeCode = "CM" | "CO" | "CN";
+
+export type CourseResultType =
+  | {
+      type: "mark";
+      mark: number;
+    }
+  | {
+      type: "competency";
+      code: CompetencyGradeCode;
+    };
+
+export type CourseTerm = "T1" | "T2" | "T3";
+
 export type CourseAchievementCardDataType = {
   course: string;
-  grade?: number;
+  result?: CourseResultType;
   description: string;
   year: number;
+  term?: CourseTerm;
 };
 
 export type CompetitionCardDataType = {

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -554,41 +554,82 @@ export const CourseAchievementCardData: CourseAchievementCardDataType[] = [
     description:
       "Built Teamer, an AI-powered team formation platform, as a solo developer. Selected as one of the best thesis projects of 2025 and presented at the CSE Thesis Showcase.",
     year: 2025,
+    result: {
+      type: "mark",
+      mark: 87,
+    },
+  },
+  {
+    course: "Human Computer Interaction (COMP3511)",
+    description:
+      "Applied user-centred design methods to create an AI legal help website for the common man, focusing on accessible interaction flows, prototyping, evaluation, and usability.",
+    year: 2025,
+    term: "T2",
+    result: {
+      type: "mark",
+      mark: 85,
+    },
+  },
+  {
+    course: "Professional Issues and Ethics (COMP4920)",
+    description:
+      "Researched AI ethics, focusing on moral reasoning, professional responsibility, accountability, privacy, fairness, and algorithmic bias in real-world computing contexts.",
+    year: 2025,
+    term: "T1",
+    result: {
+      type: "competency",
+      code: "CM",
+    },
   },
   {
     course: "Web Front-End Programming (COMP6080)",
     description:
       "Built multiple front-end web applications using vanilla JavaScript, React, and modern CSS, assessed through individual projects with strict quality and accessibility requirements.",
     year: 2024,
-    grade: 97,
+    result: {
+      type: "mark",
+      mark: 97,
+    },
   },
   {
     course: "Computer Graphics (COMP3421)",
     description:
       "Implemented 3D rendering pipelines, ray tracing, and shader programming using OpenGL and WebGL fundamentals.",
     year: 2024,
-    grade: 92,
+    result: {
+      type: "mark",
+      mark: 92,
+    },
   },
   {
     course: "Engineering Design and Professional Practice (DESN2000)",
     description:
       "Developed a prototype of a Educational Finance Management Mobile App called Figma Life in Figma, and maintained a Design Journal Documenting the entire design process methods used and followed.",
     year: 2023,
-    grade: 88,
+    result: {
+      type: "mark",
+      mark: 88,
+    },
   },
   {
     course: "Requirements and Design Workshop (SENG2021)",
     description:
       "Developed e-invoice management website using the T3 stack and an ExpressJS backend API for invoice validation and rendering in a team.",
     year: 2023,
-    grade: 81,
+    result: {
+      type: "mark",
+      mark: 81,
+    },
   },
   {
     course: "Backend Development (COMP1531)",
     description:
       "Developed an ExpressJS Backend written in Typescript for a Microsoft Teams clone in a team of 5.",
     year: 2022,
-    grade: 85,
+    result: {
+      type: "mark",
+      mark: 85,
+    },
   },
 ];
 


### PR DESCRIPTION
Updates the UNSW degree timeline to 2022-2026 and adds recent 2025 course results for COMP4951, COMP3511, and COMP4920. Adds typed support for both numeric marks and competency-based grades so CM can render correctly without being treated as a numeric result. Refreshes the course achievement descriptions for the HCI AI legal help website and AI ethics research topic. Validated with TypeScript no-emit and Prettier checks.